### PR TITLE
Fix proxyconfig.ini corruption and startup crashes

### DIFF
--- a/p99_sso_login_proxy/config.py
+++ b/p99_sso_login_proxy/config.py
@@ -5,13 +5,21 @@ import re
 import socket
 
 from p99_sso_login_proxy import __version_semver__, utils
+from p99_sso_login_proxy.config_repair import load_config_parser, resolve_backend_name
 
 CONFIG_FILE = "proxyconfig.ini"
 # Absolute path of the config file actually read, for diagnostics/logging.
 CONFIG_PATH = os.path.abspath(CONFIG_FILE)
-CONFIG = configparser.ConfigParser()
-CONFIG.optionxform = str
-CONFIG.read(CONFIG_FILE)
+CONFIG = load_config_parser(CONFIG_FILE)
+
+
+def _write_config():
+    """Atomically persist CONFIG to proxyconfig.ini."""
+    tmp_path = f"{CONFIG_FILE}.tmp"
+    with open(tmp_path, "w", encoding="utf-8") as configfile:
+        CONFIG.write(configfile)
+    os.replace(tmp_path, CONFIG_FILE)
+
 
 APP_NAME = "P99 Login Proxy"
 APP_VERSION = __version_semver__
@@ -109,18 +117,27 @@ if not CONFIG.has_section(_API_TOKENS_SECTION):
 
 # One-time migration: "P99 Login Proxy" -> seed both Good Guys and Marginal Threat
 _OLD_P99_NAME = "P99 Login Proxy"
+_repaired_sso_api_name = resolve_backend_name(SSO_API_NAME, url_hint=SSO_API, url_to_name=_url_to_name)
+if _repaired_sso_api_name != SSO_API_NAME:
+    SSO_API_NAME = _repaired_sso_api_name
+    CONFIG.set("DEFAULT", "sso_api_name", SSO_API_NAME)
+    _write_config()
+
 if SSO_API_NAME == _OLD_P99_NAME or (not SSO_API_NAME and _legacy_token):
     _migrate_token = CONFIG.get(_API_TOKENS_SECTION, _OLD_P99_NAME, fallback=_legacy_token)
     if _migrate_token:
         CONFIG.set(_API_TOKENS_SECTION, "Good Guys", _migrate_token)
         CONFIG.set(_API_TOKENS_SECTION, "Marginal Threat", _migrate_token)
+    if CONFIG.has_option(_API_TOKENS_SECTION, _OLD_P99_NAME):
+        CONFIG.remove_option(_API_TOKENS_SECTION, _OLD_P99_NAME)
     CONFIG.set("DEFAULT", "sso_api_name", "Good Guys")
     CONFIG.set("DEFAULT", "sso_api", "https://proxy.p99loginproxy.net")
-    with open("proxyconfig.ini", "w", encoding="utf-8") as _f:
-        CONFIG.write(_f)
+    _write_config()
     SSO_API_NAME = "Good Guys"
 
 USER_API_TOKEN = CONFIG.get(_API_TOKENS_SECTION, SSO_API_NAME, fallback="") if SSO_API_NAME else ""
+if not USER_API_TOKEN:
+    USER_API_TOKEN = _legacy_token
 
 # Variables to store account list and timestamp
 ALL_CACHED_NAMES = []
@@ -149,12 +166,16 @@ def iv():
     return ENCRYPTION_IV[:]
 
 
+def _normalize_backend_name(backend_name: str, backend_url: str | None = None) -> str:
+    """Return a safe backend name for use as an INI option key."""
+    return resolve_backend_name(backend_name, url_hint=backend_url, url_to_name=_url_to_name)
+
+
 def _set_config(global_name: str, config_key: str, value):
     """Update a module-level config global, persist it to proxyconfig.ini."""
     globals()[global_name] = value
     CONFIG.set("DEFAULT", config_key, str(value))
-    with open("proxyconfig.ini", "w", encoding="utf-8") as configfile:
-        CONFIG.write(configfile)
+    _write_config()
 
 
 def set_always_on_top(value: bool):
@@ -189,12 +210,12 @@ def set_api_token_for_backend(backend_name: str, token: str):
     Also keeps the legacy user_api_token in DEFAULT in sync when
     the token belongs to the currently active backend.
     """
-    CONFIG.set(_API_TOKENS_SECTION, backend_name, token)
-    if backend_name == globals()["SSO_API_NAME"]:
+    safe_name = _normalize_backend_name(backend_name, globals().get("SSO_API"))
+    CONFIG.set(_API_TOKENS_SECTION, safe_name, token)
+    if safe_name == globals()["SSO_API_NAME"]:
         globals()["USER_API_TOKEN"] = token
         CONFIG.set("DEFAULT", "user_api_token", token)
-    with open("proxyconfig.ini", "w", encoding="utf-8") as configfile:
-        CONFIG.write(configfile)
+    _write_config()
 
 
 def set_sso_api(backend_name: str, backend_url: str) -> str:
@@ -202,15 +223,17 @@ def set_sso_api(backend_name: str, backend_url: str) -> str:
 
     Returns the API token associated with the new backend.
     """
+    safe_name = _normalize_backend_name(backend_name, backend_url)
     globals()["SSO_API"] = backend_url
-    globals()["SSO_API_NAME"] = backend_name
+    globals()["SSO_API_NAME"] = safe_name
     CONFIG.set("DEFAULT", "sso_api", backend_url)
-    CONFIG.set("DEFAULT", "sso_api_name", backend_name)
-    token = get_api_token(backend_name)
+    CONFIG.set("DEFAULT", "sso_api_name", safe_name)
+    token = get_api_token(safe_name)
+    if not token:
+        token = CONFIG.get("DEFAULT", "user_api_token", fallback="")
     globals()["USER_API_TOKEN"] = token
     CONFIG.set("DEFAULT", "user_api_token", token)
-    with open("proxyconfig.ini", "w", encoding="utf-8") as configfile:
-        CONFIG.write(configfile)
+    _write_config()
     return token
 
 

--- a/p99_sso_login_proxy/config_repair.py
+++ b/p99_sso_login_proxy/config_repair.py
@@ -1,0 +1,301 @@
+"""Repair corrupted proxyconfig.ini files before configparser loads them."""
+
+from __future__ import annotations
+
+import configparser
+import os
+import re
+from typing import Mapping
+
+_CUSTOM_LABEL_RE = re.compile(r"^Custom:\s*(.+)$", re.IGNORECASE)
+_OLD_P99_NAME = "P99 Login Proxy"
+_API_TOKENS_SECTION = "api_tokens"
+_SSO_BACKENDS_SECTION = "sso_backends"
+_DEFAULT_SECTION = "DEFAULT"
+_TOKEN_SECTIONS = frozenset({_API_TOKENS_SECTION, _SSO_BACKENDS_SECTION})
+
+_BUILTIN_URL_TO_NAME: dict[str, str] = {
+    "https://proxy.p99loginproxy.net": "Good Guys",
+    "https://bot.kingdomdkp.com": "Kingdom",
+    "http://localhost:5998": "Localhost",
+}
+
+
+def _is_unsafe_key(name: str) -> bool:
+    return ":" in name or "=" in name
+
+
+def _parse_line(line: str, section: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith(";") or stripped.startswith("#"):
+        return None
+    if stripped.startswith("[") and stripped.endswith("]"):
+        return None
+
+    if section in _TOKEN_SECTIONS and " = " in stripped:
+        key, value = stripped.rsplit(" = ", 1)
+        return key.strip(), value.strip()
+
+    if "=" in stripped:
+        key, _, value = stripped.partition("=")
+        return key.strip(), value.strip()
+
+    return None
+
+
+def _parse_ini_text(text: str) -> dict[str, dict[str, list[str]]]:
+    """Parse an INI file, keeping duplicate keys as lists for repair."""
+    sections: dict[str, dict[str, list[str]]] = {_DEFAULT_SECTION: {}}
+    current = _DEFAULT_SECTION
+
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            current = stripped[1:-1].strip()
+            sections.setdefault(current, {})
+            continue
+
+        parsed = _parse_line(raw_line, current)
+        if parsed is None:
+            continue
+        key, value = parsed
+        sections.setdefault(current, {}).setdefault(key, []).append(value)
+
+    return sections
+
+
+def _collapse_values(values: list[str]) -> str:
+    for value in reversed(values):
+        cleaned = value.strip().rstrip("=").strip()
+        if cleaned:
+            return cleaned
+    return values[-1].strip() if values else ""
+
+
+def _url_to_name_map(sections: Mapping[str, Mapping[str, list[str]]]) -> dict[str, str]:
+    mapping = dict(_BUILTIN_URL_TO_NAME)
+    for name, values in sections.get(_SSO_BACKENDS_SECTION, {}).items():
+        url = _collapse_values(values)
+        if url and name not in mapping.values():
+            mapping.setdefault(url, name)
+    return mapping
+
+
+def _extract_url_from_value(value: str) -> str | None:
+    match = re.search(r"https?://[^\s=]+", value)
+    return match.group(0) if match else None
+
+
+def resolve_backend_name(
+    name: str,
+    *,
+    url_hint: str | None = None,
+    url_to_name: Mapping[str, str] | None = None,
+) -> str:
+    """Return a safe backend display name for persistence and token lookup."""
+    url_to_name = dict(url_to_name or _BUILTIN_URL_TO_NAME)
+
+    custom_match = _CUSTOM_LABEL_RE.match(name.strip())
+    if custom_match:
+        url = custom_match.group(1).strip()
+        return url_to_name.get(url, name.strip())
+
+    if _is_unsafe_key(name):
+        hinted = url_hint or _extract_url_from_value(name)
+        if hinted:
+            return url_to_name.get(hinted, name.strip())
+
+    return name.strip()
+
+
+def _pick_token(values: list[str]) -> str:
+    for value in reversed(values):
+        token = value.strip().rstrip("=").strip()
+        if token and "://" not in token:
+            return token
+        if " = " in value:
+            token = value.rsplit(" = ", 1)[-1].strip()
+            if token:
+                return token
+    for value in reversed(values):
+        token = value.strip().rstrip("=").strip()
+        if token:
+            return token
+    return ""
+
+
+def _repair_api_tokens(
+    tokens: dict[str, list[str]],
+    url_to_name: Mapping[str, str],
+) -> dict[str, str]:
+    repaired: dict[str, str] = {}
+
+    for raw_name, values in tokens.items():
+        token = _pick_token(values)
+        url_hint = _extract_url_from_value(_collapse_values(values))
+
+        if raw_name == "Custom" and url_hint:
+            safe_name = url_to_name.get(url_hint, raw_name)
+        else:
+            safe_name = resolve_backend_name(raw_name, url_hint=url_hint, url_to_name=url_to_name)
+
+        if _is_unsafe_key(safe_name):
+            continue
+
+        if safe_name not in repaired or (token and not repaired[safe_name]):
+            repaired[safe_name] = token
+        elif token and repaired[safe_name] != token:
+            repaired[safe_name] = token
+
+    if _OLD_P99_NAME in repaired and (
+        "Good Guys" in repaired or "Marginal Threat" in repaired
+    ):
+        repaired.pop(_OLD_P99_NAME, None)
+
+    return repaired
+
+
+def _repair_defaults(defaults: dict[str, list[str]], url_to_name: Mapping[str, str]) -> dict[str, str]:
+    repaired = {key: _collapse_values(values) for key, values in defaults.items()}
+
+    sso_api_name = repaired.get("sso_api_name", "")
+    sso_api = repaired.get("sso_api", "")
+    if sso_api_name:
+        safe_name = resolve_backend_name(sso_api_name, url_hint=sso_api or None, url_to_name=url_to_name)
+        if safe_name != sso_api_name:
+            repaired["sso_api_name"] = safe_name
+
+    return repaired
+
+
+def repair_sections(sections: Mapping[str, Mapping[str, list[str]]]) -> dict[str, dict[str, str]]:
+    """Return repaired section data ready to write."""
+    url_to_name = _url_to_name_map(sections)
+    repaired: dict[str, dict[str, str]] = {}
+
+    defaults = sections.get(_DEFAULT_SECTION, {})
+    if defaults:
+        repaired[_DEFAULT_SECTION] = _repair_defaults(defaults, url_to_name)
+
+    if _API_TOKENS_SECTION in sections:
+        repaired[_API_TOKENS_SECTION] = _repair_api_tokens(sections[_API_TOKENS_SECTION], url_to_name)
+
+    if _SSO_BACKENDS_SECTION in sections:
+        backend_repaired: dict[str, str] = {}
+        for name, values in sections[_SSO_BACKENDS_SECTION].items():
+            safe_name = resolve_backend_name(name, url_hint=_collapse_values(values), url_to_name=url_to_name)
+            if _is_unsafe_key(safe_name):
+                continue
+            backend_repaired[safe_name] = _collapse_values(values)
+        repaired[_SSO_BACKENDS_SECTION] = backend_repaired
+
+    for section, options in sections.items():
+        if section in repaired or section == _DEFAULT_SECTION:
+            continue
+        repaired[section] = {key: _collapse_values(values) for key, values in options.items()}
+
+    return repaired
+
+
+def config_text_needs_repair(text: str) -> bool:
+    sections = _parse_ini_text(text)
+    url_to_name = _url_to_name_map(sections)
+    repaired = repair_sections(sections)
+
+    if repaired.get(_DEFAULT_SECTION, {}) != {
+        key: _collapse_values(values) for key, values in sections.get(_DEFAULT_SECTION, {}).items()
+    }:
+        return True
+
+    original_tokens = {
+        key: _collapse_values(values) for key, values in sections.get(_API_TOKENS_SECTION, {}).items()
+    }
+    if repaired.get(_API_TOKENS_SECTION, {}) != original_tokens:
+        return True
+
+    for section, options in sections.items():
+        for key, values in options.items():
+            if section in _TOKEN_SECTIONS and _is_unsafe_key(key):
+                return True
+            if key == "sso_api_name" and _CUSTOM_LABEL_RE.match(_collapse_values(values)):
+                return True
+            if section == _API_TOKENS_SECTION and key == "Custom":
+                if _extract_url_from_value(_collapse_values(values)):
+                    return True
+            if len(values) > 1:
+                return True
+
+    if _OLD_P99_NAME in sections.get(_API_TOKENS_SECTION, {}) and (
+        "Good Guys" in sections.get(_API_TOKENS_SECTION, {})
+        or "Marginal Threat" in sections.get(_API_TOKENS_SECTION, {})
+    ):
+        return True
+
+    if url_to_name:
+        return False
+
+    return False
+
+
+def write_repaired_config(path: str, repaired: Mapping[str, Mapping[str, str]]) -> None:
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+
+    for section, options in repaired.items():
+        if section == _DEFAULT_SECTION:
+            for key, value in options.items():
+                parser.set(_DEFAULT_SECTION, key, value)
+        else:
+            if not parser.has_section(section):
+                parser.add_section(section)
+            for key, value in options.items():
+                parser.set(section, key, value)
+
+    tmp_path = f"{path}.tmp"
+    with open(tmp_path, "w", encoding="utf-8") as handle:
+        parser.write(handle)
+    os.replace(tmp_path, path)
+
+
+def repair_proxyconfig_ini(path: str) -> bool:
+    """Repair a proxyconfig.ini file in place. Returns True if a rewrite occurred."""
+    if not os.path.exists(path):
+        return False
+
+    with open(path, encoding="utf-8") as handle:
+        text = handle.read()
+
+    if not config_text_needs_repair(text):
+        return False
+
+    sections = _parse_ini_text(text)
+    repaired = repair_sections(sections)
+    write_repaired_config(path, repaired)
+    return True
+
+
+def load_config_parser(path: str) -> configparser.ConfigParser:
+    """Load proxyconfig.ini, repairing it first when necessary."""
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+
+    if not os.path.exists(path):
+        return parser
+
+    try:
+        parser.read(path, encoding="utf-8")
+    except (configparser.DuplicateOptionError, configparser.DuplicateSectionError):
+        repair_proxyconfig_ini(path)
+        parser = configparser.ConfigParser()
+        parser.optionxform = str
+        parser.read(path, encoding="utf-8")
+        return parser
+
+    with open(path, encoding="utf-8") as handle:
+        if config_text_needs_repair(handle.read()):
+            repair_proxyconfig_ini(path)
+            parser = configparser.ConfigParser()
+            parser.optionxform = str
+            parser.read(path, encoding="utf-8")
+
+    return parser

--- a/proxyconfig.ini.example
+++ b/proxyconfig.ini.example
@@ -10,9 +10,10 @@
 ; login_server = login.eqemulator.net
 ; login_port = 5998
 
-; SSO API backend currently in use (URL and display name)
+; SSO API backend currently in use (URL and display name).
+; Use a plain display name here (e.g. Good Guys), not the UI's "Custom: ..." label.
 ; sso_api = https://proxy.p99loginproxy.net
-; sso_api_name = P99 Login Proxy
+; sso_api_name = Good Guys
 
 ; Timeout in seconds for SSO HTTP requests
 ; sso_timeout = 10
@@ -36,6 +37,18 @@
 ; Use the built-in dark Fusion theme (set False for light theme)
 ; dark_mode = True
 
+; Warn when Rustle (unauthorized EQ client files) is detected in the install
+; warn_rustle = False
+
+; Opt in to pre-release update notifications
+; opt_into_prereleases = False
+
+; Launch EverQuest automatically when the proxy starts
+; launch_startup = False
+
+; Launch EverQuest with administrator privileges
+; launch_admin = True
+
 ; Path to the EverQuest installation directory (auto-detected if empty)
 ; eq_directory =
 
@@ -56,6 +69,12 @@
 ; CSV file containing locally-stored account credentials
 ; local_accounts_file = local_accounts.csv
 
+; CSV file containing locally-tracked character data
+; local_characters_file = local_characters.csv
+
+; Automatically add characters to local_characters.csv when they log in locally
+; auto_add_local_characters = True
+
 ; Comma-separated account names that should never be SSO-checked
 ; skip_sso_accounts =
 
@@ -63,16 +82,19 @@
 ; Each backend name maps to its own API token. When you switch backends
 ; in the UI the correct token is loaded automatically.
 ; The key is the display name from the dropdown (built-in or custom).
+; Keys must not contain ":" or "=" characters.
 ;
 ; [api_tokens]
-; P99 Login Proxy = YourTokenHere
-; My Guild Server = AnotherTokenHere
+; Good Guys = YourTokenHere
+; Marginal Threat = AnotherTokenHere
+; Kingdom = YourKingdomTokenHere
 
 ; ── Custom SSO backends ─────────────────────────────────────────────
 ; Add extra entries to the SSO API dropdown. Built-in backends are
 ; always present; entries here are appended to the list.
 ; The key is the display name shown in the dropdown; the value is the URL.
 ; Multiple entries may share the same URL (each with its own API token).
+; Keys must not contain ":" or "=" characters.
 ;
 ; [sso_backends]
 ; My Guild Server = https://guild.example.com

--- a/tests/test_config_repair.py
+++ b/tests/test_config_repair.py
@@ -1,0 +1,189 @@
+"""Tests for proxyconfig.ini repair and safe backend name handling."""
+
+from __future__ import annotations
+
+import configparser
+
+import pytest
+
+from p99_sso_login_proxy import config_repair
+
+EXAMPLE_TOKEN = "example-token-abc123"
+EXAMPLE_TOKEN_ALT = "example-token-xyz789"
+P99_PROXY_URL = "https://proxy.p99loginproxy.net"
+
+BROKEN_CONFIG = f"""[DEFAULT]
+user_api_token = {EXAMPLE_TOKEN}
+sso_api_name = Custom: {P99_PROXY_URL}
+sso_api = {P99_PROXY_URL}
+
+[api_tokens]
+P99 Login Proxy = {EXAMPLE_TOKEN}
+Good Guys = {EXAMPLE_TOKEN}
+Marginal Threat = {EXAMPLE_TOKEN}
+Custom = {P99_PROXY_URL} =
+Custom: {P99_PROXY_URL} = {EXAMPLE_TOKEN}
+"""
+
+
+def _write_config(path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def test_broken_config_repairs_without_duplicate_option_error(tmp_path):
+    ini_path = tmp_path / "proxyconfig.ini"
+    _write_config(ini_path, BROKEN_CONFIG)
+
+    assert config_repair.repair_proxyconfig_ini(str(ini_path)) is True
+
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    parser.read(ini_path, encoding="utf-8")
+
+    assert parser.get("DEFAULT", "sso_api_name") == "Good Guys"
+    assert parser.get("api_tokens", "Good Guys") == EXAMPLE_TOKEN
+    assert parser.get("api_tokens", "Marginal Threat") == EXAMPLE_TOKEN
+    assert not parser.has_option("api_tokens", "P99 Login Proxy")
+    assert not parser.has_option("api_tokens", "Custom")
+    assert not parser.has_option("api_tokens", f"Custom: {P99_PROXY_URL}")
+
+
+def test_load_config_parser_handles_duplicate_option_error(tmp_path):
+    ini_path = tmp_path / "proxyconfig.ini"
+    _write_config(ini_path, BROKEN_CONFIG)
+
+    parser = config_repair.load_config_parser(str(ini_path))
+
+    assert parser.get("DEFAULT", "sso_api_name") == "Good Guys"
+    assert parser.get("api_tokens", "Good Guys") == EXAMPLE_TOKEN
+
+
+def test_custom_sso_api_name_resolves_to_good_guys(tmp_path):
+    ini_path = tmp_path / "proxyconfig.ini"
+    _write_config(
+        ini_path,
+        f"""[DEFAULT]
+sso_api_name = Custom: {P99_PROXY_URL}
+sso_api = {P99_PROXY_URL}
+
+[api_tokens]
+Good Guys = {EXAMPLE_TOKEN}
+""",
+    )
+
+    config_repair.repair_proxyconfig_ini(str(ini_path))
+    text = ini_path.read_text(encoding="utf-8")
+    assert "sso_api_name = Good Guys" in text
+    assert "Custom:" not in text
+
+
+def test_colon_key_round_trip_repairs_to_single_entry(tmp_path):
+    ini_path = tmp_path / "proxyconfig.ini"
+    _write_config(
+        ini_path,
+        f"""[DEFAULT]
+sso_api_name = Good Guys
+sso_api = {P99_PROXY_URL}
+
+[api_tokens]
+Custom: {P99_PROXY_URL} = {EXAMPLE_TOKEN_ALT}
+""",
+    )
+
+    config_repair.repair_proxyconfig_ini(str(ini_path))
+
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    parser.read(ini_path, encoding="utf-8")
+
+    assert parser.get("api_tokens", "Good Guys") == EXAMPLE_TOKEN_ALT
+    assert not parser.has_option("api_tokens", "Custom")
+    assert not parser.has_option("api_tokens", f"Custom: {P99_PROXY_URL}")
+
+
+def test_migration_removes_stale_p99_login_proxy_key(tmp_path):
+    ini_path = tmp_path / "proxyconfig.ini"
+    _write_config(
+        ini_path,
+        f"""[DEFAULT]
+sso_api_name = Good Guys
+sso_api = {P99_PROXY_URL}
+
+[api_tokens]
+P99 Login Proxy = {EXAMPLE_TOKEN}
+Good Guys = {EXAMPLE_TOKEN}
+Marginal Threat = {EXAMPLE_TOKEN}
+""",
+    )
+
+    assert config_repair.config_text_needs_repair(ini_path.read_text(encoding="utf-8")) is True
+    config_repair.repair_proxyconfig_ini(str(ini_path))
+
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    parser.read(ini_path, encoding="utf-8")
+
+    assert not parser.has_option("api_tokens", "P99 Login Proxy")
+    assert parser.get("api_tokens", "Good Guys") == EXAMPLE_TOKEN
+
+
+def test_resolve_backend_name_normalizes_custom_label():
+    resolved = config_repair.resolve_backend_name(
+        f"Custom: {P99_PROXY_URL}",
+        url_hint=P99_PROXY_URL,
+    )
+    assert resolved == "Good Guys"
+
+
+def test_set_api_token_normalizes_unsafe_backend_name(tmp_path, monkeypatch):
+    ini_path = tmp_path / "proxyconfig.ini"
+    _write_config(
+        ini_path,
+        f"""[DEFAULT]
+sso_api_name = Good Guys
+sso_api = {P99_PROXY_URL}
+user_api_token =
+
+[api_tokens]
+Good Guys =
+""",
+    )
+
+    from p99_sso_login_proxy import config
+
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    parser.read(ini_path, encoding="utf-8")
+
+    monkeypatch.setattr(config, "CONFIG_FILE", str(ini_path))
+    monkeypatch.setattr(config, "CONFIG", parser)
+    monkeypatch.setattr(config, "SSO_API_NAME", "Good Guys")
+    monkeypatch.setattr(config, "SSO_API", P99_PROXY_URL)
+
+    config.set_api_token_for_backend(f"Custom: {P99_PROXY_URL}", EXAMPLE_TOKEN_ALT)
+
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    parser.read(ini_path, encoding="utf-8")
+
+    assert parser.get("api_tokens", "Good Guys") == EXAMPLE_TOKEN_ALT
+    assert not parser.has_option("api_tokens", f"Custom: {P99_PROXY_URL}")
+
+
+def test_healthy_config_is_not_rewritten(tmp_path):
+    ini_path = tmp_path / "proxyconfig.ini"
+    healthy = f"""[DEFAULT]
+sso_api_name = Good Guys
+sso_api = {P99_PROXY_URL}
+user_api_token = {EXAMPLE_TOKEN}
+
+[api_tokens]
+Good Guys = {EXAMPLE_TOKEN}
+Marginal Threat = {EXAMPLE_TOKEN}
+"""
+    _write_config(ini_path, healthy)
+    mtime_before = ini_path.stat().st_mtime_ns
+
+    assert config_repair.repair_proxyconfig_ini(str(ini_path)) is False
+    assert ini_path.read_text(encoding="utf-8") == healthy
+    assert ini_path.stat().st_mtime_ns == mtime_before


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes startup crashes caused by corrupted `proxyconfig.ini` files. A historical UI bug saved `"Custom: {url}"` display labels as backend names; Python's `configparser` treats `:` as a delimiter, which misparses `[api_tokens]` keys and eventually triggers `DuplicateOptionError` before the app can load.

## Changes

- **Auto-repair on load** (`config_repair.py`): Tolerant INI parsing detects and fixes duplicate keys, colon-containing backend names, misparsed `Custom` remnants, and stale `P99 Login Proxy` migration entries
- **Safe writes** (`config.py`): Normalize backend names before persisting; atomic file writes via temp + rename
- **Migration cleanup**: Remove stale `P99 Login Proxy` token key after seeding `Good Guys` / `Marginal Threat`
- **Token fallback**: Use legacy `user_api_token` from `[DEFAULT]` when per-backend lookup is empty
- **Tests**: Regression coverage using synthetic placeholder tokens (not user-reported values)
- **Docs**: Full rewrite of `proxyconfig.ini.example` with all user-facing options (no encryption section)

## Example repair

A broken config with duplicate `Custom` keys and `sso_api_name = Custom: https://proxy.p99loginproxy.net` is repaired on startup to:

```ini
[DEFAULT]
sso_api_name = Good Guys
sso_api = https://proxy.p99loginproxy.net

[api_tokens]
Good Guys = <preserved token>
Marginal Threat = <preserved token>
```

Healthy configs are not rewritten.

## Test plan

- [x] `pytest tests/test_config_repair.py` (8 tests)
- [x] Verified repair handles the reported corruption pattern without `DuplicateOptionError`
- [x] Verified healthy configs are left unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3f58-9595-7626-b5e8-6bf331e7b9cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3f58-9595-7626-b5e8-6bf331e7b9cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

